### PR TITLE
don't cary search term between users

### DIFF
--- a/hackathon/views.py
+++ b/hackathon/views.py
@@ -92,7 +92,8 @@ def users_page(request):
 		Users.filter(username=selected_list).update(is_admin=admin_value)
 		# return render(request, 'users.html')
 
-	print request.method 
+	request.session['stts'] = '' #clear search parameter from user_page
+	
 	if 'gn' in request.session:
 		group_name = request.session['gn']
 	else:


### PR DESCRIPTION
When searching a survey list on user, the search term is saved on the session. We don't want to cary that search term over from one user page to the next. This change clears the data on the session when visiting the users_page. If someone were to enter a URL directly (maybe a bookmark), this won't work.
